### PR TITLE
Use dom-context for event contract

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1618,6 +1618,11 @@
       "integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
       "dev": true
     },
+    "dom-context": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/dom-context/-/dom-context-0.0.1.tgz",
+      "integrity": "sha512-xRlheyCL2oW56fyXG/315tjsECtVFxy7d18CwVlpe3GNXG88V4TBxo9PI2lW8SUpT9BG2Tzaw0jNf/beZOjrgg=="
+    },
     "domexception": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
@@ -2063,7 +2068,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2084,12 +2090,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2104,17 +2112,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2231,7 +2242,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2243,6 +2255,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2257,6 +2270,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2264,12 +2278,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2288,6 +2304,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2368,7 +2385,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2380,6 +2398,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2465,7 +2484,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2501,6 +2521,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2520,6 +2541,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2563,12 +2585,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -36,5 +36,8 @@
     "puppeteer": "2.0.0",
     "rimraf": "^3.0.0"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "dependencies": {
+    "dom-context": "0.0.1"
+  }
 }

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -67,12 +67,10 @@ declare namespace LocalJSX {
   interface MyComponentChild {}
   interface MyComponentGrandchild {}
   interface StencilConsumer {
-    'onMountConsumer'?: (event: CustomEvent<any>) => void;
     'renderer'?: any;
   }
   interface StencilProvider {
     'STENCIL_CONTEXT'?: { [key: string]: any };
-    'onMountConsumer'?: (event: CustomEvent<any>) => void;
   }
 
   interface IntrinsicElements {

--- a/src/components/stencil-consumer/stencil-consumer.tsx
+++ b/src/components/stencil-consumer/stencil-consumer.tsx
@@ -1,4 +1,7 @@
-import { Component, Event, EventEmitter, Prop, State } from '@stencil/core';
+import { Component, Event, Element, EventEmitter, Prop, State } from '@stencil/core';
+
+import { context } from '../../shared';
+import { ContextListener } from 'dom-context';
 
 @Component({
   tag: 'stencil-consumer',
@@ -6,27 +9,25 @@ import { Component, Event, EventEmitter, Prop, State } from '@stencil/core';
 export class StencilConsumer {
   @Prop() renderer: any;
   @State() context: any;
-  @Event({ eventName: 'mountConsumer' }) mountEmitter: EventEmitter;
-  @State() promise: Promise<any>;
+  @Element() element:HTMLElement;
   @State() resolvePromise: any;
 
+  listener:ContextListener<Record<string,any>>
+
   constructor() {
-    this.promise = new Promise((resolve) => {
-      this.resolvePromise = resolve;
+    this.listener = new context.Listener({
+      element: this.element,
+      onChange: (next)=>this.context=next,
+      onStatus: ()=>{}
     });
   }
 
-  setContext = async (context: any) => {
-    this.context = context;
-    return this.promise;
-  };
-
   componentWillLoad() {
-    this.mountEmitter.emit(this.setContext);
+    this.listener.start()
   }
 
   componentDidUnload() {
-    this.resolvePromise();
+    this.listener.stop()
   }
 
   render() {

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,0 +1,4 @@
+import {createContext} from "dom-context";
+
+
+export const context = createContext<Record<string,any>>("mountConsumer");


### PR DESCRIPTION
There are a number of libraries that use a similar dom context approach as proposed by Justin Fagnani in 2016, see the readme here: https://github.com/saasquatch/dom-context/tree/v1

Looking to centralize all the libraries on a standard event contract.

Opening this pull request to see if you're open to the collaboration.

The goal is to keep your external API intact so it doesn't create any breaking changes for your consumers.